### PR TITLE
Controllers with params in routing prefix

### DIFF
--- a/recess/recess/framework/controllers/Controller.class.php
+++ b/recess/recess/framework/controllers/Controller.class.php
@@ -117,6 +117,19 @@ abstract class Controller extends AbstractController {
 				$url = substr($url, 1);
 			}
 			
+			// Checks if the routes prefix has some parameters and 
+			// replaces them with actual values from request meta data.
+			$prefixParts = explode('/',$descriptor->routesPrefix);
+			$prefixParams = array();
+			$prefixParamValues = array();
+			foreach($prefixParts as $part) {
+				if(strpos($part, '$') !== false) {
+					$prefixParams[] = $part;
+					$prefixParamValues[] = $this->request->meta->controllerMethodArguments[substr($part,1)];
+				}
+			}
+			$url = str_replace($prefixParams, $prefixParamValues, $url);
+			
 			if(!empty($args)) {
 				$reflectedMethod = new ReflectionMethod($this, $methodName);
 				$parameters = $reflectedMethod->getParameters();


### PR DESCRIPTION
Some controllers may have parameters in "Routing Prefix" too.

This is a very useful feature if we want to generally parametrize all the requests for that controller.

So, in those cases we need to replace such params as well with their actual values when generating the URL using "urlTo()" method.
